### PR TITLE
fix: deviceprofile_syncer should list deviceprofiles with fieldSelector spec.nodePool

### DIFF
--- a/controllers/deviceprofile_controller.go
+++ b/controllers/deviceprofile_controller.go
@@ -121,6 +121,14 @@ func (r *DeviceProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	r.NodePool = nodePool
 
+	// register the filter field for deviceprofile
+	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &devicev1alpha1.DeviceProfile{}, "spec.nodePool", func(rawObj client.Object) []string {
+		profile := rawObj.(*devicev1alpha1.DeviceProfile)
+		return []string{profile.Spec.NodePool}
+	}); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&devicev1alpha1.DeviceProfile{}).
 		WithEventFilter(genFirstUpdateFilter("deviceprofile", r.Log)).

--- a/controllers/deviceprofile_syncer.go
+++ b/controllers/deviceprofile_syncer.go
@@ -87,7 +87,8 @@ func (ds *DeviceProfileSyncer) Run(stop <-chan struct{}) {
 			addNodePoolField(eDevs, ds.NodePool)
 			// list devices on Kubernetes
 			var kDevs devicev1alpha1.DeviceProfileList
-			if err := ds.List(context.TODO(), &kDevs); err != nil {
+			listOptions := client.MatchingFields{"spec.nodePool": ds.NodePool}
+			if err := ds.List(context.TODO(), &kDevs, listOptions); err != nil {
 				ds.log.Error(err, "fail to list the deviceprofile object on the Kubernetes")
 				continue
 			}


### PR DESCRIPTION

#### What type of PR is this?
 /kind bug

#### What this PR does / why we need it:

yurt-device-controller is responsible for lifecycle and syncing of the resources(CR) in the same nodepool with it. So the deviceprofile_syncer should list resource in openyurt with fieldSelector spec.nodePool.


#### Does this PR introduce a user-facing change?
NONE
