### PR TITLE
Fix bug in deviceprofile synchronization process

### DIFF
--- a/api/v1alpha1/deviceprofile_types.go
+++ b/api/v1alpha1/deviceprofile_types.go
@@ -20,6 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	DeviceProfileFinalizer = "v1alpha1.deviceProfile.finalizer"
+)
+
 type DeviceResource struct {
 	Description string            `json:"description"`
 	Name        string            `json:"name"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/bug
#### What this PR does / why we need it:
Fix bugs and solve the following problems：
- **Problem one:** After deleting the deviceprofile through edgex-core-metadata, the corresponding deviceprofile on openyurt will not be deleted;
- **Problem two:** With the restart of yurt-device-controller, openyurt may have a deviceprofile with two nodepool prefixes in its name.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #18 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @wawlian 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
