### PR TITLE
do not interrupt sync logic when non-fatal error occured

### DIFF
--- a/controllers/device_syncer.go
+++ b/controllers/device_syncer.go
@@ -87,19 +87,16 @@ func (ds *DeviceSyncer) Run(stop <-chan struct{}) {
 			// 3. create device on OpenYurt which are exists in edge platform but not in OpenYurt
 			if err := ds.syncEdgeToKube(redundantEdgeDevices); err != nil {
 				klog.V(3).ErrorS(err, "fail to create devices on OpenYurt")
-				continue
 			}
 
 			// 4. delete redundant device on OpenYurt
 			if err := ds.deleteDevices(redundantKubeDevices); err != nil {
 				klog.V(3).ErrorS(err, "fail to delete redundant devices on OpenYurt")
-				continue
 			}
 
 			// 5. update device status on OpenYurt
 			if err := ds.updateDevices(syncedDevices); err != nil {
 				klog.V(3).ErrorS(err, "fail to update devices status")
-				continue
 			}
 			klog.V(2).Info("[Device] One round of synchronization is complete")
 		}
@@ -153,8 +150,10 @@ func (ds *DeviceSyncer) findDiffDevice(
 		ed := edgeDevices[i]
 		edName := util.GetEdgeDeviceName(&ed, EdgeXObjectName)
 		if _, exists := kubeDevices[edName]; !exists {
+			klog.V(5).Infof("found redundant edge device %s", edName)
 			redundantEdgeDevices[edName] = ds.completeCreateContent(&ed)
 		} else {
+			klog.V(5).Infof("found device %s to be synced", edName)
 			kd := kubeDevices[edName]
 			syncedDevices[edName] = ds.completeUpdateContent(&kd, &ed)
 		}

--- a/controllers/deviceprofile_syncer.go
+++ b/controllers/deviceprofile_syncer.go
@@ -88,13 +88,11 @@ func (dps *DeviceProfileSyncer) Run(stop <-chan struct{}) {
 			// 3. create deviceProfiles on OpenYurt which are exists in edge platform but not in OpenYurt
 			if err := dps.syncEdgeToKube(redundantEdgeDeviceProfiles); err != nil {
 				klog.V(3).ErrorS(err, "fail to create deviceProfiles on OpenYurt")
-				continue
 			}
 
 			// 4. delete redundant deviceProfiles on OpenYurt
 			if err := dps.deleteDeviceProfiles(redundantKubeDeviceProfiles); err != nil {
 				klog.V(3).ErrorS(err, "fail to delete redundant deviceProfiles on OpenYurt")
-				continue
 			}
 
 			// 5. update deviceProfiles on OpenYurt

--- a/controllers/deviceservice_syncer.go
+++ b/controllers/deviceservice_syncer.go
@@ -84,19 +84,16 @@ func (ds *DeviceServiceSyncer) Run(stop <-chan struct{}) {
 			// 3. create deviceServices on OpenYurt which are exists in edge platform but not in OpenYurt
 			if err := ds.syncEdgeToKube(redundantEdgeDeviceServices); err != nil {
 				klog.V(3).ErrorS(err, "fail to create deviceServices on OpenYurt")
-				continue
 			}
 
 			// 4. delete redundant deviceServices on OpenYurt
 			if err := ds.deleteDeviceServices(redundantKubeDeviceServices); err != nil {
 				klog.V(3).ErrorS(err, "fail to delete redundant deviceServices on OpenYurt")
-				continue
 			}
 
 			// 5. update deviceService status on OpenYurt
 			if err := ds.updateDeviceServices(syncedDeviceServices); err != nil {
 				klog.V(3).ErrorS(err, "fail to update deviceServices")
-				continue
 			}
 			klog.V(2).Info("[DeviceService] One round of synchronization is complete")
 		}


### PR DESCRIPTION
/kind enhancement

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Do not interrupt sync logic when non-fatal error occurs. For example, if syncing device from edge platform to k8s fails, sync logic can continue to execute to  avoid interrupt updating device status from edge platform to k8s resource.

#### Special notes for your reviewer:
/assign @qclc 

#### Does this PR introduce a user-facing change?
NONE
