### PR TITLE
some enhancements when communication with edgex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
 	k8s.io/klog/v2 v2.9.0


### PR DESCRIPTION
…ve the property name according to the edgex parameter names

#### What type of PR is this?
/kind enhancement

#### What this PR does / why we need it:

1. Set default timeout for httpclient to avoid potential goroutine stucking
2. retrieve property name from put.parameterNames when updating property

#### Special notes for your reviewer:

/assign @qclc 


#### Does this PR introduce a user-facing change?
NONE

