### PR TITLE
add docker buildx support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ build:
 release:
 	bash hack/make-rules/release-images.sh
 
+buildx-release:
+	docker buildx build --no-cache --push --platform linux/arm64,linux/amd64 -f hack/Dockerfile . -t ${IMG}
+
 clean:
 	-rm -Rf bin
 	-rm -Rf _output

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,0 +1,13 @@
+FROM --platform=${BUILDPLATFORM} golang:1.18 as builder
+ADD . /build
+ARG TARGETOS TARGETARCH
+WORKDIR /build/
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build
+
+FROM --platform=${TARGETPLATFORM} alpine:3.17
+ARG TARGETOS TARGETARCH
+WORKDIR /
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories && \
+    apk add ca-certificates bash libc6-compat iptables ip6tables && update-ca-certificates && rm /var/cache/apk/*
+COPY --from=builder /build/_output/bin/${TARGETOS}/${TARGETARCH}/yurt-device-controller /yurt-device-controller
+ENTRYPOINT ["/yurt-device-controller"]


### PR DESCRIPTION
#### What type of PR is this?
 /kind enhancement

#### What this PR does / why we need it:
add docker buildx multi-arch image building support

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:
@lwmqwer 


#### Does this PR introduce a user-facing change?
users can now build multi-arch image with `export IMG=xxx;make buildx-release` 